### PR TITLE
Add support for launchpad vendor

### DIFF
--- a/changelogs/changelogs.py
+++ b/changelogs/changelogs.py
@@ -80,6 +80,16 @@ def _bootstrap_functions(name, vendor, functions):
             "get_releases": rubygems.get_releases,
             "get_urls": rubygems.get_urls,
         })
+    elif vendor == "launchpad":
+        from . import launchpad
+        fns.update({
+            "get_metadata": launchpad.get_metadata,
+            "get_releases": launchpad.get_releases,
+            "get_urls": launchpad.get_urls,
+            "find_changelogs": launchpad.find_changelogs,
+            "get_content": launchpad.get_content,
+            "parse": launchpad.parse
+        })
 
     # load custom functions for special packages lying in custom/{vendor}/{package}.py
     custom_fns = _load_custom_functions(vendor=vendor, name=name)

--- a/changelogs/finder.py
+++ b/changelogs/finder.py
@@ -31,6 +31,8 @@ def validate_repo_url(url):
             return re.findall(r"https?://w?w?w?.?github.com/[\w\-]+/[\w.-]+", url)[0]
         elif "bitbucket.org" in url:
             return re.findall(r"https?://bitbucket.org/[\w.-]+/[\w.-]+", url)[0] + "/src/"
+        elif "launchpad.net" in url:
+            return re.findall(r"https?://launchpad.net/[\w.-]+", url)[0]
     except IndexError:
         pass
     return ""

--- a/changelogs/launchpad.py
+++ b/changelogs/launchpad.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+
+
+def get_metadata(session, name):
+    """
+    Gets meta data from launchpad for the given package.
+    :param session: requests Session instance
+    :param name: str, package
+    :return: dict, meta data
+    """
+    resp = session.get(
+        "https://api.launchpad.net/1.0/{}/releases".format(name))
+    if resp.status_code == 200:
+        return resp.json()
+    return {}
+
+
+def get_releases(data, **kwargs):
+    """
+    Gets all releases from pypi meta data.
+    :param data: dict, meta data
+    :return: list, str releases
+    """
+    if "entries" in data:
+        return [e["version"] for e in data["entries"]]
+    return []
+
+
+def find_changelogs(session, name, candidates):
+    """
+    Tries to find changelogs on the given URL candidates
+    :param session: requests Session instance
+    :param name: str, project name
+    :param candidates: list, URL candidates
+    :return: tuple, (set(changelog URLs), set(repo URLs))
+    """
+    return set(), set()
+
+
+def get_urls(session, name, data, find_changelogs_fn, **kwargs):
+    """
+    Gets URLs to changelogs.
+    :param session: requests Session instance
+    :param name: str, package name
+    :param data: dict, meta data
+    :param find_changelogs_fn: function, find_changelogs
+    :return: tuple, (set(changelog URLs), set(repo URLs))
+    """
+    # if this package has valid meta data, build up a list of URL candidates we can possibly
+    # search for changelogs on
+    return {"https://api.launchpad.net/1.0/{}/releases".format(name)}, set()
+
+
+def get_content(session, urls):
+    """
+    Loads the content from URLs, ignoring connection errors.
+    :param session: requests Session instance
+    :param urls: list, str URLs
+    :return: str, content
+    """
+    for url in urls:
+        resp = session.get(url)
+        if resp.ok:
+            return resp.json()
+    return {}
+
+
+def parse(name, content, releases, get_head_fn):
+    """
+    Parses the given content for a valid changelog
+    :param name: str, package name
+    :param content: str, content
+    :param releases: list, releases
+    :param get_head_fn: function
+    :return: dict, changelog
+    """
+    return {e["version"]: e["changelog"] for e in content["entries"]}


### PR DESCRIPTION
I've added support for [launchpad](https://launchpad.net/) as a vendor here. There are a few python projects hosted in launchpad out there. And they have the changelog integrated directly in that platform. 

Along side that I've also added an implementation to change vendors if no changelogs are found and some hints show that the project is hosted elsewhere. 

I've only activated this for pypi -> launchpad. This could work for others as well, but this is the only one I've tested. E.g. project [dkimpy](https://pypi.python.org/pypi/dkimpy):

```
~ $ changelogs dkimpy
0.6.2
    - Fixed python3.4 string interpolation issue
    - Fix some byte casting issues & typos
    - Add test case for verification when should headers are signed


0.6.1
    - Fixed python3 dns lookup issue
    - Fixed arcverify.py issue


0.6.0
    - Add capability to sign and verify ARC signatures
    - Added new script, dknewkey.py, to generate DKIM keys

```