### PR TITLE
Add changelog parsers for my packages

### DIFF
--- a/changelogs/custom/pypi/arcgis2geojson.py
+++ b/changelogs/custom/pypi/arcgis2geojson.py
@@ -1,0 +1,13 @@
+import re
+
+def get_urls(releases, **kwargs):
+    return {
+        'https://raw.githubusercontent.com/chris48s/arcgis2geojson/master/CHANGELOG.md'
+    }, set()
+
+def get_head(line, releases, **kwargs):
+    for release in releases:
+        pattern = re.compile(r"## :package: [[]?{}[]]?.+".format(release))
+        if pattern.match(line):
+            return release
+    return False

--- a/changelogs/custom/pypi/commitment.py
+++ b/changelogs/custom/pypi/commitment.py
@@ -1,0 +1,13 @@
+import re
+
+def get_urls(releases, **kwargs):
+    return {
+        'https://raw.githubusercontent.com/chris48s/commitment/master/CHANGELOG.md'
+    }, set()
+
+def get_head(line, releases, **kwargs):
+    for release in releases:
+        pattern = re.compile(r"## :package: [[]?{}[]]?.+".format(release))
+        if pattern.match(line):
+            return release
+    return False

--- a/changelogs/custom/pypi/django_apiblueprint_view.py
+++ b/changelogs/custom/pypi/django_apiblueprint_view.py
@@ -1,0 +1,13 @@
+import re
+
+def get_urls(releases, **kwargs):
+    return {
+        'https://raw.githubusercontent.com/chris48s/django-apiblueprint-view/master/CHANGELOG.md'
+    }, set()
+
+def get_head(line, releases, **kwargs):
+    for release in releases:
+        pattern = re.compile(r"## :package: [[]?{}[]]?.+".format(release))
+        if pattern.match(line):
+            return release
+    return False

--- a/changelogs/custom/pypi/eco_parser.py
+++ b/changelogs/custom/pypi/eco_parser.py
@@ -1,0 +1,13 @@
+import re
+
+def get_urls(releases, **kwargs):
+    return {
+        'https://raw.githubusercontent.com/DemocracyClub/eco-parser/master/CHANGELOG.md'
+    }, set()
+
+def get_head(line, releases, **kwargs):
+    for release in releases:
+        pattern = re.compile(r"## :package: [[]?{}[]]?.+".format(release))
+        if pattern.match(line):
+            return release
+    return False

--- a/changelogs/custom/pypi/uk_election_ids.py
+++ b/changelogs/custom/pypi/uk_election_ids.py
@@ -1,0 +1,13 @@
+import re
+
+def get_urls(releases, **kwargs):
+    return {
+        'https://raw.githubusercontent.com/DemocracyClub/uk-election-ids/master/CHANGELOG.md'
+    }, set()
+
+def get_head(line, releases, **kwargs):
+    for release in releases:
+        pattern = re.compile(r"## :package: [[]?{}[]]?.+".format(release))
+        if pattern.match(line):
+            return release
+    return False

--- a/changelogs/custom/pypi/uk_geo_utils.py
+++ b/changelogs/custom/pypi/uk_geo_utils.py
@@ -1,0 +1,13 @@
+import re
+
+def get_urls(releases, **kwargs):
+    return {
+        'https://raw.githubusercontent.com/DemocracyClub/uk-geo-utils/master/CHANGELOG.md'
+    }, set()
+
+def get_head(line, releases, **kwargs):
+    for release in releases:
+        pattern = re.compile(r"## :package: [[]?{}[]]?.+".format(release))
+        if pattern.match(line):
+            return release
+    return False


### PR DESCRIPTION
Add changelog parsers for [my packages](https://pypi.org/user/chris48s/). They are mostly not that widely used, but I use pyup on several of of my projects and I was getting frustrated with "_The bot wasn't able to find a changelog for this release_". Hopefully you will accept them.