### PR TITLE
Use 'if tree in not None' to fix a deprecation warning in finder.py

### DIFF
--- a/changelogs/finder.py
+++ b/changelogs/finder.py
@@ -73,7 +73,7 @@ def find_repo_urls(session, name, candidates):
                 resp = session.get(_url)
                 if resp.status_code == 200:
                     tree = etree.HTML(resp.content)
-                    if tree:
+                    if tree is not None:
                         for link in frozenset([str(l) for l in tree.xpath("//a/@href")]):
                             # check if the link 1) is to github.com / bitbucket.org AND 2) somewhat
                             # contains the project name


### PR DESCRIPTION
Hello,

This is a little patch to get rid of that warning:
```
The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
```