### PR TITLE
Update jinja2 changelog link

### DIFF
--- a/changelogs/custom/pypi/jinja2.py
+++ b/changelogs/custom/pypi/jinja2.py
@@ -1,4 +1,4 @@
 def get_urls(*args, **kwargs):
     return {
-        'https://raw.githubusercontent.com/pallets/jinja/master/CHANGES'
+        'https://raw.githubusercontent.com/pallets/jinja/main/CHANGES.rst'
     }, set()


### PR DESCRIPTION
This Pull Request aims to update the changelog link from Jinja2. Our current changelog link is broke due to change on the original link so we must update it. 