### PR TITLE
feat: add poetry changelog

### DIFF
--- a/changelogs/custom/pypi/map.txt
+++ b/changelogs/custom/pypi/map.txt
@@ -29,6 +29,7 @@ osc: https://raw.githubusercontent.com/openSUSE/osc/master/NEWS
 pdfminer.six: https://raw.githubusercontent.com/pdfminer/pdfminer.six/master/CHANGELOG.md
 phonenumbers: https://raw.githubusercontent.com/google/libphonenumber/master/release_notes.txt
 pinax-stripe: https://raw.githubusercontent.com/pinax/pinax-stripe/master/docs/about/release-notes.md
+poetry: https://github.com/python-poetry/poetry/blob/main/CHANGELOG.md
 pytest: https://raw.githubusercontent.com/pytest-dev/pytest/master/doc/en/changelog.rst
 python-memcached: https://raw.githubusercontent.com/linsomniac/python-memcached/master/ChangeLog
 python-social-auth: https://raw.githubusercontent.com/python-social-auth/social-core/master/CHANGELOG.md


### PR DESCRIPTION
Poetry changelog are not being displayed on its provided page:
![Screenshot from 2025-04-10 18-45-11](https://github.com/user-attachments/assets/a3964f48-70cd-4746-ba90-d35f9ab258d7)
